### PR TITLE
Use Java 21 in actions

### DIFF
--- a/.github/workflows/gradle-check.yml
+++ b/.github/workflows/gradle-check.yml
@@ -12,6 +12,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v4
 

--- a/.github/workflows/jvm-publish.yml
+++ b/.github/workflows/jvm-publish.yml
@@ -14,6 +14,11 @@ jobs:
   build-and-publish:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Probably does not change anything for this repo, but since the [backend](https://github.com/Besi97/inventory-backend) has to be built with a newer version, it would be safer to have them in sync.